### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/backend/api/routes/cocktail_r.js
+++ b/backend/api/routes/cocktail_r.js
@@ -2,9 +2,17 @@
 const express = require('express')
 const cocktailCtrl = require('../controllers/cocktail_c')
 const checkToken = require('../middleware/checkJwt')
+const rateLimit = require('express-rate-limit') // Import rate limiter
 
 /*** EEXPRESS ROUTER */
 let router = express.Router()
+
+/*** RATE LIMITER */
+const deleteRateLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // Limit each IP to 10 delete requests per minute
+  message: "Too many delete requests from this IP, please try again later."
+})
 
 /*** COCKTAIL ROUTAGE */
 router.get('/', cocktailCtrl.getAllCocktails)
@@ -13,6 +21,6 @@ router.get('/:id([0-9]+)', cocktailCtrl.getCocktail)
 router.put('/', checkToken, cocktailCtrl.addCocktail)
 router.patch('/:id([0-9]+)', checkToken, cocktailCtrl.modifyCocktail)
 
-router.delete('/:id([0-9]+)', checkToken, cocktailCtrl.deleteCocktail)
+router.delete('/:id([0-9]+)', checkToken, deleteRateLimiter, cocktailCtrl.deleteCocktail)
 
 module.exports = router

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,8 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.9.7",
-        "sequelize": "^6.37.3"
+        "sequelize": "^6.37.3",
+        "express-rate-limit": "^7.5.0"
     },
     "devDependencies": {
         "jest": "^29.7.0",


### PR DESCRIPTION
Potential fix for [https://github.com/ValentinWlt/golf/security/code-scanning/17](https://github.com/ValentinWlt/golf/security/code-scanning/17)

To fix the issue, we will add rate limiting to the `delete` route using the `express-rate-limit` package. This will ensure that the number of requests to the route is capped within a specified time window, mitigating the risk of DoS attacks.

Steps to implement the fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 10 requests per minute).
4. Apply the rate limiter to the `delete` route on line 16.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
